### PR TITLE
Optimize record-facts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,1 @@
+(defproject tolitius/verter "dev-placeholder")

--- a/project.clj
+++ b/project.clj
@@ -1,1 +1,0 @@
-(defproject tolitius/verter "dev-placeholder")

--- a/src/verter/store/postgres.clj
+++ b/src/verter/store/postgres.clj
@@ -3,8 +3,6 @@
             [next.jdbc.sql.builder :as qb]
             [next.jdbc.date-time]
             [next.jdbc.result-set :as jdbcr]
-            [clojure.edn :as edn]
-            [taoensso.nippy :as nippy]
             [verter.core :as v]
             [verter.tools :as vt]
             [inquery.core :as q]))
@@ -32,7 +30,7 @@
                             do nothing"]
     [tx-id tx-time (concat [(str qhead qfoot)] data)]))
 
-(defn- record-transaction [{:keys [ds schema queries]}
+(defn- record-transaction [{:keys [ds schema]}
                            facts]
   (let [[tx-id tx-time sql] (make-insert-txs-batch-query schema facts)
         recorded (jdbc/execute! ds sql)]
@@ -45,8 +43,7 @@
 (defn- record-facts [{:keys [ds schema]}
                      facts]
   (let [sql (make-insert-facts-batch-query schema facts)]
-    (jdbc/execute! ds sql
-                   {:return-keys true :builder-fn jdbcr/as-unqualified-lower-maps})))
+    (jdbc/execute! ds sql)))
 
 (defn- find-facts
   "find all the facts about identity upto a certain time"


### PR DESCRIPTION
The removed options to execute! return the rows that were inserted. However, we are not using any information about the records inserted into facts.  We do not need to return them from the DB.  Removing the options cuts the execution time down.  

The result of record-facts is not passed on.  record-facts is a private functions so it would be used anywhere else.
![image](https://user-images.githubusercontent.com/33734037/225990015-d6f608e9-94a0-4386-8729-9d9edc0ebe5b.png)
