### PR TITLE
Use the newest version of nippy

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {tolitius/inquery {:mvn/version "0.1.19"}
         tolitius/calip {:mvn/version "0.1.13"}
         com.danboykis/cljhash {:mvn/version "0.1.0"}
-        com.taoensso/nippy {:mvn/version "3.2.0"}
+        com.taoensso/nippy {:mvn/version "3.4.2"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.955"}}
  :aliases {:dev {:extra-paths ["dev"]
                  ;; :main-opts ["-i" "dev/dev.clj" "-e" "(in-ns,'dev)"]


### PR DESCRIPTION
com.taoensso does a check to ensure a minimum version of encore is used when compiling.  The version required by nippy 3.2.0 is now too old.  Bump nippy to the latest version.  nippy docs indicate that all versions since 3.2 are non breaking.

https://github.com/taoensso/nippy/releases